### PR TITLE
Enhance order retrieval performance with prefetch_related and add Django Silk for profiling

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -21,7 +21,7 @@ def product_detail(request, pk):
 
 @api_view(['GET'])
 def order_list(request):
-    orders = Order.objects.all()
+    orders = Order.objects.prefetch_related('items__product')
     serializer = OrderSerializer(orders, many=True)
     return Response(serializer.data)
 

--- a/order_managment/settings.py
+++ b/order_managment/settings.py
@@ -39,7 +39,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django_extensions',
     'rest_framework',
-    'api'
+    'api',
+    'silk',
 ]
 
 MIDDLEWARE = [
@@ -50,6 +51,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'silk.middleware.SilkyMiddleware',
 ]
 
 ROOT_URLCONF = 'order_managment.urls'

--- a/order_managment/urls.py
+++ b/order_managment/urls.py
@@ -21,4 +21,5 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('api.urls')),
+    path('silk/', include('silk.urls', namespace='silk')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ django
 djangorestframework
 pillow
 django-extensions
+django-silk


### PR DESCRIPTION
Enhance order retrieval performance with prefetch_related and add Django Silk for profiling
<img width="2920" height="506" alt="django-silk" src="https://github.com/user-attachments/assets/16e72fe4-b84f-4e61-865f-b9c3ad78e336" />
